### PR TITLE
Remove image_transport_plugins, message_generation dependencies

### DIFF
--- a/h264_video_encoder/package.xml
+++ b/h264_video_encoder/package.xml
@@ -16,7 +16,6 @@
   <build_depend>aws_ros2_common</build_depend>
   <build_depend>aws_common</build_depend>
   <build_depend>image_transport</build_depend>
-  <build_depend>message_generation</build_depend>
   <build_depend>rmw_implementation</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>sensor_msgs</build_depend>

--- a/h264_video_encoder/package.xml
+++ b/h264_video_encoder/package.xml
@@ -23,7 +23,6 @@
   <build_depend>kinesis_video_msgs</build_depend>
 
   <exec_depend>image_transport</exec_depend>
-  <exec_depend>image_transport_plugins</exec_depend>
   <exec_depend>aws_ros2_common</exec_depend>
   <exec_depend>aws_common</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>


### PR DESCRIPTION
No such packages in ROS2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
